### PR TITLE
Update roles in setup script

### DIFF
--- a/scripts/setup-google-cloud.sh
+++ b/scripts/setup-google-cloud.sh
@@ -126,13 +126,12 @@ log "Created networking service account: $PACKAGE_NAME-net-sa"
 roles=(
   "roles/artifactregistry.admin"
   "roles/run.admin"
-  "roles/run.domainMappingAdmin"
   "roles/iam.serviceAccountUser"
   "roles/iam.serviceAccountTokenCreator"
   "roles/compute.loadBalancerAdmin"
   "roles/compute.networkAdmin"
   "roles/compute.securityAdmin"
-  "roles/certificatemanager.admin"
+  "roles/certificatemanager.owner"
   "roles/dns.admin"
 )
 


### PR DESCRIPTION
## Overview (Required)

This Pull Request updates the roles in the `setup-google-cloud.sh` script. Specifically, it modifies certain roles to better align with the required permissions for Google Cloud services.

## Changes (Required)

### Updates to roles:

- Replaced the role `roles/certificatemanager.admin` with `roles/certificatemanager.owner`.

## Review Priority (Required)

- [ ] Medium (Review needed within a week)

## Related Issues/Projects

- Issues

  - None

- Projects
  - None

## Breaking Changes (Required)

- [ ] No

## Impact Scope (Required)

- [ ] Configuration changes
- [ ] None (Code cleanup)

## Testing

### Build/Test

- [ ] `nps build` completes successfully
- [ ] `nps docker.build` completes successfully
- [ ] `nps test` passes

### Functionality Check

- [ ] Verified in local environment
- [ ] Verified in staging environment

## Screenshots

- Not applicable

## Deployment Steps

- [ ] Can be handled with the usual deployment steps

## Notes

- This Pull Request only modifies roles and does not introduce new functionality.