### PR TITLE
Enhance setup script for Cloud Run

### DIFF
--- a/scripts/setup-google-cloud.sh
+++ b/scripts/setup-google-cloud.sh
@@ -168,13 +168,14 @@ log "Added IAM policy binding for application service account (repository)."
 # Enable require services                                                     #
 ###############################################################################
 
-## Enable required services
 services=(
-  "compute.googleapis.com"
-  "domains.googleapis.com"
-  "dns.googleapis.com"
-  "certificatemanager.googleapis.com"
-  "iamcredentials.googleapis.com"
+  "iamcredentials.googleapis.com"     ## Google Auth
+  "compute.googleapis.com"            ## Load balancer
+  "domains.googleapis.com"            ## Cloud domain
+  "dns.googleapis.com"                ## Cloud dns
+  "certificatemanager.googleapis.com" ## Certificate manager
+  "artifactregistry.googleapis.com"   ## Artifact repository
+  "run.googleapis.com"                ## Cloud run
 )
 
 for service in "${services[@]}"; do


### PR DESCRIPTION
### Summary
Enhance `setup-google-cloud.sh` script to include additional services required for Cloud Run and other functionalities.

### Changes
- Added `artifactregistry.googleapis.com` for Artifact repository.
- Added `run.googleapis.com` for Cloud Run.
- Included comments for better clarity on the purpose of each service.

### References
None

### Breaking changes
- [ ] Yes
- [X] No