### PR TITLE
Add public directory to Dockerfile

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -62,6 +62,7 @@ WORKDIR /app
 COPY --from=installer /app/node_modules ./node_modules
 COPY --from=sourcer /app/apps/web/.next ./apps/web/.next
 COPY --from=sourcer /app/apps/web/package.json ./apps/web/package.json
+COPY --from=sourcer /app/apps/web/public ./apps/web/public
 
 # Set working directory to the web application directory
 WORKDIR /app/apps/web/


### PR DESCRIPTION
## Overview (Required)

Adds configuration to copy the `public` directory to the Dockerfile for `apps/web`.

## Changes (Required)

- ### Dockerfile Update
  - Added `COPY --from=sourcer /app/apps/web/public ./apps/web/public` to `apps/web/Dockerfile`. This ensures that static files within the `public` directory of the Next.js application are included in the Docker image.

## Review Priority (Required)

- [ ] Urgent (Review needed within the day)
- [ ] High (Review needed within 2 business days)
- [x] Medium (Review needed within a week)
- [ ] Low (Review when you have time)

## Related Issues/Projects

- Issues

- Projects

## Breaking Changes (Required)

- [ ] Yes (Describe details below)
- [x] No

## Impact Scope (Required)

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [ ] Configuration changes
- [ ] Environment variable changes
- [x] None (Code cleanup)

## Testing

### Build/Test

- [ ] `nps build` completes successfully
- [x] `nps docker.build` completes successfully
- [ ] `nps test` passes

### Functionality Check

- [x] Verified in local environment
- [ ] Verified in staging environment

## Screenshots


## Deployment Steps

- [x] Can be handled with the usual deployment steps
- [ ] Special steps required (Describe details below)

## Notes
