### PR TITLE
Fix test workflow use string 'true' and add changes job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,11 +78,11 @@ jobs:
             ${{ runner.os }}-yarn-
       - run: yarn global add turbo
       - name: Prepare
-        if: matrix.run == true
+        if: matrix.run == 'true'
         run: npx nps prepare.ci.${{ matrix.target }}
       - name: Build
-        if: matrix.run == true
+        if: matrix.run == 'true'
         run: npx nps build.ci.${{ matrix.target }}
       - name: Test
-        if: matrix.run == true
+        if: matrix.run == 'true'
         run: npx nps test.ci.${{ matrix.target }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
       - run: yarn install --frozen-lockfile
 
   test:
-    needs: setup
+    needs: [setup, changes]
     runs-on: ubuntu-latest
     if: needs.setup.result == 'success'
     strategy:


### PR DESCRIPTION
## Overview

This pull request updates the test workflow to use the string 'true' for matrix.run conditionals and adds the 'changes' job back to the test job dependencies.

## Changes

- ### Fix of test workflow conditionals
  - Update 'if' conditions in test workflow jobs to use the string 'true' instead of boolean true.
  - Add 'changes' back to the test job's needs array, so it now depends on both 'setup' and 'changes'.

## Breaking Changes

- [ ] Yes
- [x] No

## Impact Scope

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [ ] Configuration changes
- [ ] Environment variable changes
- [x] None (Code cleanup)

## Testing

<details>
  <summary>nps docker.build</summary>
  <!-- 
    ... Build log 
  -->
</details>

<details>
  <summary>nps test</summary>
  <!-- 
    ... Test log 
  -->
</details>

## Screenshots

<!--
  If there are UI changes, share before/after using one of the following methods:

  1. Screenshots
  2. GIF, MP4
-->

## Notes

<!--
  - Points to note for reviewers
  - Concerns in implementation
  - Additional tasks needed
  - Future issues
  etc., if any, please describe
-->
